### PR TITLE
Skip low quality reads for rmdupdep - fixes #12

### DIFF
--- a/bamdst.c
+++ b/bamdst.c
@@ -855,7 +855,7 @@ int load_bamfiles(struct opt_aux *f, aux_t * a, bamflag_t * fs)
             // secondary alignment
             if ( ret == 3 ) goto endcore;
             
-	    if (ret > 1) {
+	    if (ret == 2 || !(c->qual > f->mapQ_lim) ) {
 		state = CDUP;
 	    } else {
 		if (c->flag & BAM_FREAD1) fs->n_rmdup1++;


### PR DESCRIPTION
This PR makes the code match the documentation with respect to excluding low quality reads from the rmdup depth calculations.